### PR TITLE
Fix zip file size calculation and update error handling in functions.…

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -15,7 +15,7 @@ def zip_files(path, part_size, filename, password)->Path:
 
 	dir_files = path
 	partsdir=dir_files.parent.joinpath("parts")
-	size = int(part_size) if part_size else 2000
+	size = int(part_size) if part_size else 2000 * _MEGABYTE
 	copy_filter = [{"id": FILTER_COPY}]
 	encryption = False
 	try:
@@ -35,7 +35,7 @@ def zip_files(path, part_size, filename, password)->Path:
 		file_path = dir_files.joinpath(file)
 		total_size += file_path.stat().st_size
 
-	smaller=(total_size < size * _MEGABYTE)
+	smaller=(total_size < size)
 
 	if smaller:
 
@@ -50,7 +50,7 @@ def zip_files(path, part_size, filename, password)->Path:
 
 		with multivolumefile.open(
 			f"{partsdir}/{filename_7z}",
-			"wb",size * _MEGABYTE
+			"wb",size
 		) as target_archive:
 			with SevenZipFile(
 					target_archive,"w",filters=copy_filter,

--- a/main.py
+++ b/main.py
@@ -22,7 +22,8 @@ import pyrogram.errors
 from humanize import naturalsize
 from pyrogram import Client, filters, idle
 from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup, Message
-from pyromod import listen
+from pyromod import Client as PyromodClient  # noqa: F401 - patches pyrogram.Client
+from pyromod.exceptions import ListenerTimeout
 
 from functions import *
 
@@ -207,8 +208,8 @@ async def rename_file(client, message):
         f"Select the file number to rename:\n{file_options}"
     )
     try:
-        response = await client.listen(user_id, filters=filters.text, timeout=60)
-    except asyncio.TimeoutError:
+        response = await client.listen(chat_id=user_id, filters=filters.text, timeout=60)
+    except ListenerTimeout:
         await prompt_message.edit_text("No response received. Operation cancelled.")
         return
 
@@ -235,8 +236,8 @@ async def rename_file(client, message):
         f"Enter the new name for **{old_filename}** (include the extension):"
     )
     try:
-        response = await client.listen(user_id, filters=filters.text, timeout=60)
-    except asyncio.TimeoutError:
+        response = await client.listen(chat_id=user_id, filters=filters.text, timeout=60)
+    except ListenerTimeout:
         await prompt_message.edit_text("No response received. Operation cancelled.")
         return
 
@@ -367,7 +368,7 @@ async def compress(client, message):
             filters=filters.text,
             timeout=60,
         )
-    except asyncio.TimeoutError:
+    except ListenerTimeout:
         await message.reply_text("No response received. Operation cancelled.")
         return
 
@@ -385,7 +386,7 @@ async def compress(client, message):
             filters=filters.text,
             timeout=60,
         )
-    except asyncio.TimeoutError:
+    except ListenerTimeout:
         await message.reply_text("No response received. Operation cancelled.")
         return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pyrofork==2.3.40
 TgCrypto-pyrofork==1.2.6
 multivolumefile==0.2.3
 py7zr==0.18.9
-pyromod==1.5
+pyromod==3.1.6
 humanize==4.2.0
 pypdl==1.4.4
 aiohttp==3.11.0

--- a/start.sh
+++ b/start.sh
@@ -6,6 +6,9 @@ URL_HFS="https://github.com/carlos-a-g-h/asere-hfs/releases/download/2023-08-23/
 # Path to public dir
 PATH_PUBLIC="/app/public"
 
+# Default PORT to 8000 if not set
+PORT="${PORT:-8000}"
+
 # (debug) Show the PORT env var
 echo "WEB SERVER PORT = $PORT"
 
@@ -16,8 +19,12 @@ python3 pull.py asere-hfs "$URL_HFS"
 mkdir -p "$PATH_PUBLIC"
 
 # Give execution permit and run the HFS in background
-chmod +x asere-hfs
-./asere-hfs --port $PORT --master "$PATH_PUBLIC" &
+if [ -f asere-hfs ]; then
+  chmod +x asere-hfs
+  ./asere-hfs --port $PORT --master "$PATH_PUBLIC" &
+else
+  echo "WARNING: HFS binary not found, file server will not be available"
+fi
 
 # (debug) Show the PID of the HFS
 echo "HTTP FILE SERVER PID = $(pidof asere-hfs)"


### PR DESCRIPTION
Changes made
1. pyromod upgrade (most likely crash cause) — [requirements.txt](vscode-webview://0ha12mhgr9j4tk8527eoj247ipe41l5l14i81qlbgdk20vg65lct/requirements.txt), [main.py](vscode-webview://0ha12mhgr9j4tk8527eoj247ipe41l5l14i81qlbgdk20vg65lct/main.py)

Upgraded pyromod from 1.5 to 3.1.6 — the old version predates pyrofork and had a different API
Updated import: from pyromod import listen → importing Client (triggers monkeypatching) + ListenerTimeout
Fixed client.listen() calls: first positional arg changed from chat_id to filters in 3.x, so switched to explicit chat_id= keyword arg
Replaced asyncio.TimeoutError catches with ListenerTimeout (pyromod 3.x's exception type)
2. Double _MEGABYTE multiplication — [functions.py](vscode-webview://0ha12mhgr9j4tk8527eoj247ipe41l5l14i81qlbgdk20vg65lct/functions.py)

main.py already multiplied by _MEGABYTE before passing to zip_files, but functions.py multiplied again — making the effective size value * _MEGABYTE² (trillions of bytes)
Removed the extra multiplication from both the comparison and the multivolumefile.open() call
Fixed the default (no size specified) from bare 2000 to 2000 * _MEGABYTE so the unit is consistent (bytes)
3. start.sh resilience — [start.sh](vscode-webview://0ha12mhgr9j4tk8527eoj247ipe41l5l14i81qlbgdk20vg65lct/start.sh)

Added PORT="${PORT:-8000}" default so the HFS server doesn't fail with an empty --port
Added a file-existence check before trying to run the HFS binary, so a failed download doesn't crash the entire startup script